### PR TITLE
feat(workflows): add routine WASP Hive testing

### DIFF
--- a/.github/workflows/wasp_hive_testing.yaml
+++ b/.github/workflows/wasp_hive_testing.yaml
@@ -11,8 +11,7 @@ jobs:
       API_BASE_URL: ${{ secrets.RUN_API_URL }}
       API_KEY: ${{ secrets.RUN_API_KEY }}
       POLL_INTERVAL: 15
-      MAX_RUNNING_DISPLAY: 20
-      HEARTBEAT_SEC: 120
+      HEARTBEAT_SEC: 300
     steps:
       - name: Install tools
         run: |
@@ -39,45 +38,54 @@ jobs:
           set -euo pipefail
           TASK_ID='${{ steps.trigger.outputs.task_id }}'
           BASE="${API_BASE_URL%/}"
-          last_line=""
+          last_block=""
           last_ts=$(date +%s)
-          i=0
+
           while true; do
-            i=$((i+1))
             RESP=$(curl -sS "$BASE/tasks/$TASK_ID" -H "X-API-Key: $API_KEY" || true)
             if [ -z "$RESP" ]; then
               echo "(warn) empty response" >&2
               sleep "$POLL_INTERVAL"; continue
             fi
+
             STATUS=$(echo "$RESP" | jq -r '.task.status // "unknown"')
             SUMMARY=$(echo "$RESP" | jq -r '.progress.summary_line // "waiting for progress"')
             RUN_ARR=$(echo "$RESP" | jq '.progress.running // []')
             COUNT=$(echo "$RUN_ARR" | jq 'length')
+
             if [ "$COUNT" -eq 0 ]; then
-              NAMES='-'
+              LIST="- (none)"
             else
-              NAMES=$(echo "$RUN_ARR" | jq -r "sort_by(.id) | .[0:$MAX_RUNNING_DISPLAY] | map(.name) | join(\", \")")
-              if [ "$COUNT" -gt "$MAX_RUNNING_DISPLAY" ]; then
-                EXTRA=$(( COUNT - MAX_RUNNING_DISPLAY ))
-                NAMES="$NAMES, …(+${EXTRA} more)"
-              fi
+              LIST=$(echo "$RUN_ARR" | jq -r \
+                "sort_by(.name) | .[] | \"- \(.name)\"")
             fi
-            LINE="running: $NAMES, $SUMMARY"
-            if [ ${#LINE} -gt 380 ]; then
-              LINE="${LINE:0:360} …[truncated]"
-            fi
+
+            {
+              echo "running:"
+              if [ -n "$LIST" ]; then echo "$LIST"; fi
+              echo "summary: $SUMMARY"
+            } > /tmp/prog_block.txt
+
             now=$(date +%s)
-            if [ "$LINE" != "$last_line" ] || [ $(( now - last_ts )) -ge "$HEARTBEAT_SEC" ]; then
-              echo "$LINE"
-              last_line="$LINE"; last_ts=$now
+            cur_block=$(cat /tmp/prog_block.txt)
+
+            if [ "$cur_block" != "$last_block" ] || [ $(( now - last_ts )) -ge "$HEARTBEAT_SEC" ]; then
+              echo "$cur_block"
+              last_block="$cur_block"
+              last_ts=$now
             fi
+
             if [ "$STATUS" = "succeeded" ]; then
-              echo "FINAL: $LINE"; break
+              echo "FINAL:"
+              echo "$cur_block"
+              break
             elif [ "$STATUS" = "failed" ]; then
               EXIT_CODE=$(echo "$RESP" | jq -r '.task.exit_code // ""')
-              echo "FINAL: $LINE (failed exit_code=$EXIT_CODE)" >&2
+              echo "FINAL (failed exit_code=$EXIT_CODE):"
+              echo "$cur_block" >&2
               exit 1
             fi
+
             sleep "$POLL_INTERVAL"
           done
 
@@ -91,4 +99,4 @@ jobs:
             echo "Unexpected final status: $STATUS" >&2
             exit 1
           fi
-          echo "Task $TASK_ID completed successfully"
+          echo "Testing completed successfully"

--- a/.github/workflows/wasp_hive_testing.yaml
+++ b/.github/workflows/wasp_hive_testing.yaml
@@ -1,0 +1,94 @@
+name: WASP Hive Routine Testing
+on:
+  schedule:
+    - cron: "0 0 * * 6"
+  workflow_dispatch:
+
+jobs:
+  trigger:
+    runs-on: self-hosted
+    env:
+      API_BASE_URL: ${{ secrets.RUN_API_URL }}
+      API_KEY: ${{ secrets.RUN_API_KEY }}
+      POLL_INTERVAL: 15
+      MAX_RUNNING_DISPLAY: 20
+      HEARTBEAT_SEC: 120
+    steps:
+      - name: Install tools
+        run: |
+          sudo apt-get update -y && sudo apt-get install -y jq
+
+      - name: Trigger WASP Hive Testing
+        id: trigger
+        run: |
+          set -euo pipefail
+          URL="${API_BASE_URL%/}/run"
+          RESP=$(curl -sS -X POST "$URL" \
+            -H "X-API-Key: $API_KEY" \
+            -H "Content-Type: application/json")
+          echo "Response: $RESP"
+          TASK_ID=$(echo "$RESP" | jq -r '.task_id')
+          if [ -z "$TASK_ID" ] || [ "$TASK_ID" = "null" ]; then
+            echo "No task_id in response" >&2
+            exit 1
+          fi
+          echo "task_id=$TASK_ID" >> "$GITHUB_OUTPUT"
+
+      - name: Monitoring Progress
+        run: |
+          set -euo pipefail
+          TASK_ID='${{ steps.trigger.outputs.task_id }}'
+          BASE="${API_BASE_URL%/}"
+          last_line=""
+          last_ts=$(date +%s)
+          i=0
+          while true; do
+            i=$((i+1))
+            RESP=$(curl -sS "$BASE/tasks/$TASK_ID" -H "X-API-Key: $API_KEY" || true)
+            if [ -z "$RESP" ]; then
+              echo "(warn) empty response" >&2
+              sleep "$POLL_INTERVAL"; continue
+            fi
+            STATUS=$(echo "$RESP" | jq -r '.task.status // "unknown"')
+            SUMMARY=$(echo "$RESP" | jq -r '.progress.summary_line // "waiting for progress"')
+            RUN_ARR=$(echo "$RESP" | jq '.progress.running // []')
+            COUNT=$(echo "$RUN_ARR" | jq 'length')
+            if [ "$COUNT" -eq 0 ]; then
+              NAMES='-'
+            else
+              NAMES=$(echo "$RUN_ARR" | jq -r "sort_by(.id) | .[0:$MAX_RUNNING_DISPLAY] | map(.name) | join(\", \")")
+              if [ "$COUNT" -gt "$MAX_RUNNING_DISPLAY" ]; then
+                EXTRA=$(( COUNT - MAX_RUNNING_DISPLAY ))
+                NAMES="$NAMES, …(+${EXTRA} more)"
+              fi
+            fi
+            LINE="running: $NAMES, $SUMMARY"
+            if [ ${#LINE} -gt 380 ]; then
+              LINE="${LINE:0:360} …[truncated]"
+            fi
+            now=$(date +%s)
+            if [ "$LINE" != "$last_line" ] || [ $(( now - last_ts )) -ge "$HEARTBEAT_SEC" ]; then
+              echo "$LINE"
+              last_line="$LINE"; last_ts=$now
+            fi
+            if [ "$STATUS" = "succeeded" ]; then
+              echo "FINAL: $LINE"; break
+            elif [ "$STATUS" = "failed" ]; then
+              EXIT_CODE=$(echo "$RESP" | jq -r '.task.exit_code // ""')
+              echo "FINAL: $LINE (failed exit_code=$EXIT_CODE)" >&2
+              exit 1
+            fi
+            sleep "$POLL_INTERVAL"
+          done
+
+      - name: Final Status
+        run: |
+          set -euo pipefail
+          TASK_ID='${{ steps.trigger.outputs.task_id }}'
+          RESP=$(curl -sS "${API_BASE_URL%/}/tasks/$TASK_ID" -H "X-API-Key: $API_KEY")
+          STATUS=$(echo "$RESP" | jq -r '.task.status')
+          if [ "$STATUS" != "succeeded" ]; then
+            echo "Unexpected final status: $STATUS" >&2
+            exit 1
+          fi
+          echo "Task $TASK_ID completed successfully"


### PR DESCRIPTION
This workflow triggers the API on the WASP Hive Testing Server to start tests.

All running tests will be displayed in the GitHub Actions log. By default, GitHub checks the API every 15 seconds, and the action log will only update when there are changes in the testing items.

This workflow has already been tested locally using `act`, following is the sample output:
```
| running:
| - "tests/cancun/eip4844_blobs/test_blob_txs.py::test_valid_blob_tx_combinations[fork_Cancun-blobs_per_tx_(1, 1, 1, 1, 1)-blockchain_test_engine-block_base_fee_per_gas_7]-wasp-client"
| - tests/cancun/eip4844_blobs/test_blobhash_opcode.py::test_blobhash_gas_cost[fork_Cancun-tx_type_1-blockchain_test_engine_from_state_test-blobhash_index_115792089237316195423570985008687907853269984665640564039457584007913129639935]-wasp-client
| - tests/cancun/eip4844_blobs/test_excess_blob_gas.py::test_correct_excess_blob_gas_calculation[fork_Prague-parent_excess_blobs_4-parent_blobs_5-blockchain_test_engine-new_blobs_1]-wasp-client
| - tests/cancun/eip4844_blobs/test_excess_blob_gas.py::test_invalid_excess_blob_gas_target_blobs_increase_from_zero[fork_Prague-parent_blobs_2-header_excess_blobs_delta_3-blockchain_test_engine-new_blobs_1-parent_excess_blobs_0]-wasp-client
| - tests/frontier/opcodes/test_dup.py::test_dup[fork_Paris-evm_code_type_LEGACY-blockchain_test_engine_from_state_test-DUP10]-wasp-client
| - tests/istanbul/eip152_blake2/test_blake2.py::test_blake2b_gas_limit[fork_Shanghai-gas_limit_110000-blockchain_test_engine_from_state_test-EIP-152-case6-data7-gas-limit-call_opcode_CALLCODE]-wasp-client
| - tests/osaka/eip7823_modexp_upper_bounds/test_modexp_upper_bounds.py::test_modexp_upper_bounds[fork_Prague-blockchain_test_engine_from_state_test-excess_length_base]-wasp-client
| summary: 0/7 finished (0 pass, 0 fail, 7 running)
| running:
| - "tests/cancun/eip4844_blobs/test_blob_txs.py::test_valid_blob_tx_combinations[fork_Cancun-blobs_per_tx_(1, 1, 1, 1, 1)-blockchain_test_engine-block_base_fee_per_gas_7]-wasp-client"
| - tests/berlin/eip2930_access_list/test_tx_intrinsic_gas.py::test_tx_intrinsic_gas[fork_Cancun-tx_type_1-blockchain_test_engine_from_state_test-below_intrinsic_True-access_list_empty-data_set_32_bytes]-wasp-client
| - tests/berlin/eip2930_access_list/test_tx_intrinsic_gas.py::test_tx_intrinsic_gas[fork_Prague-tx_type_1-blockchain_test_engine_from_state_test-below_intrinsic_True-access_list_empty-data_1_zero_byte]-wasp-client
| - tests/cancun/eip4844_blobs/test_blob_txs.py::test_sufficient_balance_blob_tx[fork_Prague-single_blob-blockchain_test_engine_from_state_test-tx_max_fee_per_blob_gas_multiplier_1-block_base_fee_per_gas_7-single_one_calldata-tx_value_1-tx_max_priority_fee_per_gas_0-tx_max_fee_per_gas_14-access_list]-wasp-client
| - tests/cancun/eip4844_blobs/test_blobhash_opcode.py::test_blobhash_gas_cost[fork_Cancun-tx_type_1-blockchain_test_engine_from_state_test-blobhash_index_115792089237316195423570985008687907853269984665640564039457584007913129639935]-wasp-client
| - tests/cancun/eip4844_blobs/test_excess_blob_gas.py::test_correct_excess_blob_gas_calculation[fork_Prague-parent_excess_blobs_4-parent_blobs_5-blockchain_test_engine-new_blobs_1]-wasp-client
| - tests/cancun/eip4844_blobs/test_excess_blob_gas.py::test_invalid_excess_blob_gas_target_blobs_increase_from_zero[fork_Prague-parent_blobs_2-header_excess_blobs_delta_3-blockchain_test_engine-new_blobs_1-parent_excess_blobs_0]-wasp-client
| - tests/frontier/opcodes/test_dup.py::test_dup[fork_Paris-evm_code_type_LEGACY-blockchain_test_engine_from_state_test-DUP10]-wasp-client
| - tests/istanbul/eip152_blake2/test_blake2.py::test_blake2b_gas_limit[fork_Shanghai-gas_limit_110000-blockchain_test_engine_from_state_test-EIP-152-case6-data7-gas-limit-call_opcode_CALLCODE]-wasp-client
| - tests/osaka/eip7823_modexp_upper_bounds/test_modexp_upper_bounds.py::test_modexp_upper_bounds[fork_Prague-blockchain_test_engine_from_state_test-excess_length_base]-wasp-client
| summary: 0/10 finished (0 pass, 0 fail, 10 running)
```